### PR TITLE
EMBR-5183  code coverage report failing to parse reports

### DIFF
--- a/__tests__/__snapshots__/utils.test.ts.snap
+++ b/__tests__/__snapshots__/utils.test.ts.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parse cobertura file with empty classes 1`] = `
+{
+  "basePath": "",
+  "coverage": 49.83,
+  "files": {},
+  "timestamp": 1715832361332,
+}
+`;
+
+exports[`parse cobertura file with empty lines 1`] = `
+{
+  "basePath": "src/main.ts",
+  "coverage": 49.83,
+  "files": {
+    "4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d": {
+      "absolute": "src/main.ts",
+      "coverage": 0,
+      "relative": "src/main.ts",
+    },
+  },
+  "timestamp": 1715832361332,
+}
+`;
+
+exports[`parse cobertura file with empty methods 1`] = `
+{
+  "basePath": "src/main.ts",
+  "coverage": 49.83,
+  "files": {
+    "4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d": {
+      "absolute": "src/main.ts",
+      "coverage": 0,
+      "relative": "src/main.ts",
+    },
+  },
+  "timestamp": 1715832361332,
+}
+`;
+
+exports[`parse cobertura file with empty packages 1`] = `
+{
+  "basePath": "",
+  "coverage": 0,
+  "files": {},
+  "timestamp": 1716003335,
+}
+`;
+
 exports[`parse empty cobertura file 1`] = `
 {
   "basePath": "",

--- a/__tests__/fixtures/cobertura-empty-classes.xml
+++ b/__tests__/fixtures/cobertura-empty-classes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="303" lines-covered="151" line-rate="0.49829999999999997" branches-valid="143" branches-covered="64" branch-rate="0.4475" timestamp="1715832361332" complexity="0" version="0.1">
+  <sources>
+    <source>/usr/src/code-coverage-report-action</source>
+  </sources>
+  <packages>
+    <package name="src" line-rate="0.4058" branch-rate="0.4083">
+      <classes>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/__tests__/fixtures/cobertura-empty-lines.xml
+++ b/__tests__/fixtures/cobertura-empty-lines.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="303" lines-covered="151" line-rate="0.49829999999999997" branches-valid="143" branches-covered="64" branch-rate="0.4475" timestamp="1715832361332" complexity="0" version="0.1">
+  <sources>
+    <source>/usr/src/code-coverage-report-action</source>
+  </sources>
+  <packages>
+    <package name="src" line-rate="0.4058" branch-rate="0.4083">
+      <classes>
+        <class name="main.ts" filename="src/main.ts" line-rate="0" branch-rate="0">
+          <methods>
+            <method name="run" hits="0" signature="()V">
+              <lines>
+              </lines>
+            </method>
+            <method name="generateMarkdown" hits="0" signature="()V">
+              <lines>
+                <line number="107" hits="0"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/__tests__/fixtures/cobertura-empty-methods.xml
+++ b/__tests__/fixtures/cobertura-empty-methods.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="303" lines-covered="151" line-rate="0.49829999999999997" branches-valid="143" branches-covered="64" branch-rate="0.4475" timestamp="1715832361332" complexity="0" version="0.1">
+  <sources>
+    <source>/usr/src/code-coverage-report-action</source>
+  </sources>
+  <packages>
+    <package name="src" line-rate="0.4058" branch-rate="0.4083">
+      <classes>
+        <class name="main.ts" filename="src/main.ts" line-rate="0" branch-rate="0">
+          <methods>
+          </methods>
+          <lines>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/__tests__/fixtures/cobertura-empty-packages.xml
+++ b/__tests__/fixtures/cobertura-empty-packages.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="0" lines-covered="0" line-rate="0" branches-valid="0" branches-covered="0" branch-rate="0" timestamp="1716003335.624" complexity="0" version="5.4.3+1">
+  <sources/>
+  <packages>
+  </packages>
+</coverage>

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -173,6 +173,26 @@ test('parse empty cobertura file', async () => {
   expect(ret).toMatchSnapshot()
 })
 
+test('parse cobertura file with empty packages', async () => {
+  const ret = await parseCoverage(__dirname + '/fixtures/cobertura-empty-packages.xml')
+  expect(ret).toMatchSnapshot()
+})
+
+test('parse cobertura file with empty classes', async () => {
+  const ret = await parseCoverage(__dirname + '/fixtures/cobertura-empty-classes.xml')
+  expect(ret).toMatchSnapshot()
+})
+
+test('parse cobertura file with empty lines', async () => {
+  const ret = await parseCoverage(__dirname + '/fixtures/cobertura-empty-lines.xml')
+  expect(ret).toMatchSnapshot()
+})
+
+test('parse cobertura file with empty methods', async () => {
+  const ret = await parseCoverage(__dirname + '/fixtures/cobertura-empty-methods.xml')
+  expect(ret).toMatchSnapshot()
+})
+
 test('parse many sources cobertura file', async () => {
   const ret = await parseCoverage(
     __dirname + '/fixtures/cobertura-many-sources.xml'

--- a/src/reports/cobertura/parser/index.ts
+++ b/src/reports/cobertura/parser/index.ts
@@ -33,9 +33,9 @@ export default async function parse(cobertura: Cobertura): Promise<Coverage> {
  * @param {Package[]} packages
  * @returns {Promise<Files>}
  */
-async function parsePackages(packages: Package[]): Promise<Files> {
+async function parsePackages(packages?: Package[]): Promise<Files> {
   let allFiles: Files = {}
-  for await (const p of packages) {
+  for await (const p of packages || []) {
     if (!p.classes) {
       continue
     }
@@ -52,16 +52,18 @@ async function parsePackages(packages: Package[]): Promise<Files> {
  * @param {Class[]} classes
  * @returns {Promise<Files>}
  */
-async function parseClasses(classes: Class[]): Promise<Files> {
-  return classes.reduce(
-    (previous, {'@_filename': path, '@_line-rate': lineRate}: Class) => ({
-      ...previous,
-      [createHash(`${path}`)]: {
-        relative: path,
-        absolute: `${path}`,
-        coverage: roundPercentage(parseFloat(lineRate) * 100)
-      }
-    }),
-    {}
+async function parseClasses(classes?: Class[]): Promise<Files> {
+  return (
+    classes?.reduce(
+      (previous, {'@_filename': path, '@_line-rate': lineRate}: Class) => ({
+        ...previous,
+        [createHash(`${path}`)]: {
+          relative: path,
+          absolute: `${path}`,
+          coverage: roundPercentage(parseFloat(lineRate) * 100)
+        }
+      }),
+      {}
+    ) || {}
   )
 }

--- a/src/reports/cobertura/types/index.ts
+++ b/src/reports/cobertura/types/index.ts
@@ -22,7 +22,7 @@ export interface Coverage {
 }
 
 export interface Packages {
-  package: Package[]
+  package?: Package[]
 }
 
 export interface Package {
@@ -34,7 +34,7 @@ export interface Package {
 }
 
 export interface Classes {
-  class: Class[]
+  class?: Class[]
 }
 
 export interface Class {
@@ -48,14 +48,14 @@ export interface Class {
 }
 
 export interface Lines {
-  line: LineElement[] | PurpleLine
+  line?: LineElement[] | PurpleLine
 }
 
 export interface LineElement {
   '@_number': string
   '@_hits': string
   '@_branch'?: Boolean
-  conditions?: Conditions
+  conditions?: Conditions[] | Conditions
   '@_condition-coverage'?: string
 }
 
@@ -65,7 +65,7 @@ export enum Boolean {
 }
 
 export interface Conditions {
-  condition: ConditionElement[] | ConditionElement
+  condition?: ConditionElement[] | ConditionElement
 }
 
 export interface ConditionElement {
@@ -88,7 +88,7 @@ export interface PurpleLine {
 }
 
 export interface Methods {
-  method: MethodElement[] | MethodElement
+  method?: MethodElement[] | MethodElement
 }
 
 export interface MethodElement {


### PR DESCRIPTION
see https://github.com/clearlyip/code-coverage-report-action/issues/82. 

I will be creating a more detailed description in the mirror PR (Edit: [here it is](https://github.com/clearlyip/code-coverage-report-action/pull/88)) I am going to be creating to contribute with this back to the original open-source repo. The short of it is that the typescript interfaces were not in sync with what the [cobertura dtd spec](https://github.com/cobertura/web/blob/5ade495c8f8f5308490bdfbbbe61aafe25a1b67b/htdocs/xml/coverage-04.dtd) says, leaving a couple of potentially undefined objects not being handled correctly